### PR TITLE
IE10 doesn't have console.group. Mock it out. 

### DIFF
--- a/testpageloader.js
+++ b/testpageloader.js
@@ -9,6 +9,9 @@ var MutableEvent = require("montage/core/event/mutable-event").MutableEvent;
 var Promise = require("montage/core/promise").Promise;
 var defaultEventManager;
 
+if (!console.group) {
+    console.group = console.groupEnd = console.log;
+}
 
 var TestPageLoader = exports.TestPageLoader = Montage.specialize( {
     init: {


### PR DESCRIPTION
This fixes about half of the IE10 test failures!
