### PR TITLE
Mock key events should have a preventDefault(). 

### DIFF
--- a/testpageloader.js
+++ b/testpageloader.js
@@ -368,7 +368,7 @@ var TestPageLoader = exports.TestPageLoader = Montage.specialize( {
 
             var doc = this.iframe.contentDocument,
                 mofifiers = eventInfo.modifiers.split(" "),
-                    event = {
+                event = {
                     altGraphKey: false,
                     altKey: mofifiers.indexOf("alt") !== -1,
                     bubbles: true,
@@ -387,6 +387,7 @@ var TestPageLoader = exports.TestPageLoader = Montage.specialize( {
                     metaKey: mofifiers.indexOf("meta") !== -1,
                     pageX: 0,
                     pageY: 0,
+                    preventDefault: Function.noop,
                     returnValue: true,
                     shiftKey: mofifiers.indexOf("shift") !== -1,
                     srcElement: eventInfo.target,


### PR DESCRIPTION
Otherwise throws errors in KeyComposer tests. I think there is probably a nicer way to do this by creating a real CustomEvent and initing it, but I couldn't get that to work with setting all these properties.
