### PR TITLE
Fix an issue with Firefox and IE for our fake Events.

### DIFF
--- a/testpageloader.js
+++ b/testpageloader.js
@@ -553,6 +553,14 @@ var TestPageLoader = exports.TestPageLoader = Montage.specialize( {
                 }
             });
 
+            Object.defineProperty(fakeEvent, "bubbles", {
+                value: event.bubbles
+            });
+
+            Object.defineProperty(fakeEvent, "type", {
+                value: event.type
+            });
+
             return fakeEvent;
         }
     },


### PR DESCRIPTION
In our specs we make a new object that represent a fake Event Object from an Event, but this instance needs to be an Event object, otherwise Firefox and IE will raise an Error.
