### PR TITLE
testpageloader.js requires wrong EventManager path

### DIFF
--- a/testpageloader.js
+++ b/testpageloader.js
@@ -1,6 +1,7 @@
 /**
  * @see https://developer.mozilla.org/en/DOM/HTMLIFrameElement
  */
+
 var Montage = require("montage").Montage;
 var dom = require("montage/core/dom");
 var ActionEventListener = require("montage/core/event/action-event-listener").ActionEventListener;
@@ -154,7 +155,7 @@ var TestPageLoader = exports.TestPageLoader = Montage.specialize( {
 
                         defaultEventManager = null;
 
-                        return self.require.async("core/event/event-manager")
+                        return self.require.async("montage/core/event/event-manager")
                         .then(function (exports) {
                             defaultEventManager = exports.defaultEventManager;
                         });


### PR DESCRIPTION
Will try to load `http://localhost:8083/test/core/event/event-manager`, which causes waring in the console but doesn't break tests